### PR TITLE
fix: config in postcss.config.mjs

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,7 +1,5 @@
-import tailwindcssPostcss from "@tailwindcss/postcss";
-
 const config = {
-  plugins: [tailwindcssPostcss()],
+  plugins: ["@tailwindcss/postcss"],
 };
 
 export default config;


### PR DESCRIPTION
## Summary

This PR fixes the postcss naming bug that was breaking CD.

## Changes
Reverted this specific change

<img width="1578" height="273" alt="image" src="https://github.com/user-attachments/assets/088d45a1-06de-4c2c-bc45-c9c28a57c43a" />

## Reflection

Ngl this was a great learning lesson for me. Do not under **ANY** circumstances commit to main with code that is broken and is failing checks. So for when I wrote unittests, the branch I worked on, I never even ran npm run dev I just ran npm run test. Which worked fine however turborepo and the build process was cooked. 

## Closes #34 
