### PR TITLE
ci: add supabase keys to github secrets

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,6 +13,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY}}
+
     strategy:
       matrix:
         node-version: [22.x]
@@ -28,7 +32,4 @@ jobs:
       - run: npm ci
       - run: npm run build --if-present
       - name: Run Tests
-        env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY}}
         run: npm test


### PR DESCRIPTION
## Summary 

This PR adds our supabase keys to github's CI action using secrets so they stay safe. 

## Reflection

This was a easy fix, just had to add my supabase keys on my other personal project so fixing this was easy. Also learned that its a good idea to give the secret to the entire suite. Cause at first I only gave it to tests which is stupid cause well im not testing supabase (as of yet)

## Closes #36 