### PR TITLE
fix: typo in dashboard page test

### DIFF
--- a/src/app/dashboard/__tests__/page.test.tsx
+++ b/src/app/dashboard/__tests__/page.test.tsx
@@ -79,10 +79,9 @@ describe("Dashboard Page Tests", () => {
   it("should show Green button for Hello World if completed", async () => {
     // Override the mock for THIS test to simulate completion
     mockEq.mockResolvedValue({
-      data: [{ quiz_id: "hello-world" }],
+      data: [{ quest_id: "hello-world" }],
       error: null,
     });
-
     const page = await DashboardPage();
     render(page);
 


### PR DESCRIPTION
## Summary 
This is a small bug fix to fix the failing test in dashboard page. The issue was a typo. 

## Issues
- Closes #54 