### PR TITLE
chore: add supabase ping

### DIFF
--- a/.github/workflows/supabase-keep-alive-ping.yml
+++ b/.github/workflows/supabase-keep-alive-ping.yml
@@ -1,0 +1,19 @@
+name: Supabase Keep-Alive Ping
+on:
+  schedule:
+    # Runs at 00:00 UTC every Monday, Wednesday, and Sunday
+    - cron: "0 0 * * 1,3,7"
+  workflow_dispatch:
+
+jobs:
+  ping_db:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Supabase REST API
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+        run: |
+          curl -f -X GET "$NEXT_PUBLIC_SUPABASE_URL/rest/v1/your_tiny_table?select=id&limit=1" \
+          -H "apikey: $NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY" \
+          -H "Authorization: Bearer $NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY"


### PR DESCRIPTION
## Summary
This PR adds a cron job Github Actions workflow to ping the supabase database 3 times a week to keep it from going cold. 

## Issues
- Closes #63 